### PR TITLE
Feature: Add astro asset caching to speed up deployment

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -29,6 +29,13 @@ jobs:
       #   with:
       #     node-version: 18
 
+      - name: Restore cached
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: swa/.cache
+          key: swa-assets
+
       - name: Install dependencies
         working-directory: swa/
         run: |
@@ -51,6 +58,12 @@ jobs:
         env: # Put a node version on the following line
           NODE_VERSION: 22
           PUBLIC_RYBBIT_SITE_ID: ${{ secrets.PUBLIC_RYBBIT_SITE_ID }}
+
+      - name: Cache images
+        uses: actions/cache/save@v4
+        with:
+          path: swa/.cache
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/swa/.gitignore
+++ b/swa/.gitignore
@@ -7,6 +7,9 @@ dist/
 # dependencies
 node_modules/
 
+# cache
+.cache/
+
 # logs
 npm-debug.log*
 yarn-debug.log*

--- a/swa/astro.config.mjs
+++ b/swa/astro.config.mjs
@@ -12,4 +12,5 @@ export default defineConfig({
   integrations: [sitemap({
     customPages: [],
   })],
+  cacheDir: './.cache'
 });


### PR DESCRIPTION
Changes:

- set astro cache directory to custom `swa/.cache` directory
- use GitHub runner cache for build assets to improve deployment speed
