### PR TITLE
Feature: Set different canonical page urls for dev and prod

### DIFF
--- a/swa/src/layouts/BaseLayout.astro
+++ b/swa/src/layouts/BaseLayout.astro
@@ -12,9 +12,12 @@ const { title, description, keywords, robots } = Astro.props;
 
 const rybbitSiteId = import.meta.env.PUBLIC_RYBBIT_SITE_ID || "";
 
-const canonicalUrl = Astro.site
-  ? new URL(Astro.url.pathname, Astro.site).toString()
-  : Astro.url.toString();
+// Canonical URLs:
+// - In production, canonicalize to the configured `site` origin (see `swa/astro.config.mjs`).
+// - In local dev, canonicalize to the current dev server origin (localhost + port).
+const productionOrigin = Astro.site ? new URL(Astro.site).origin : Astro.url.origin;
+const canonicalOrigin = import.meta.env.DEV ? Astro.url.origin : productionOrigin;
+const canonicalUrl = new URL(Astro.url.pathname, canonicalOrigin).toString();
 
 ---
 


### PR DESCRIPTION
Changes:

- Use environment-aware canonical origins:
  - Local development: canonical uses `Astro.url.origin` so it becomes `http://localhost:<port>/<path>` automatically.
  - Production: canonical uses the configured site origin from `Astro.site` (set in `swa/astro.config.mjs`), so it becomes `https://clowa.dev/<path>`.
- Avoid hardcoding any domain in the layout template; canonical behavior is derived from Astro runtime variables/config.