### PR TITLE
fix(otel): stop visitor IPs reaching Middleware in traces and access logs

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -45,7 +45,17 @@
 			roll_size 5MiB
 			roll_keep 3
 		}
-		format json
+		# Drop the request headers that carry the visitor IP before the line is
+		# written, so it never reaches the on-disk log, the collector, or Middleware
+		# (privacy.md promises this). The plain json encoder logs the full header
+		# map; the filter encoder still writes json but omits these fields entirely.
+		# remote_ip/client_ip are the loopback Scaleway edge, so they need no masking.
+		format filter {
+			request>headers>X-Forwarded-For delete
+			request>headers>X-Real-Ip delete
+			request>headers>Forwarded delete
+			request>headers>X-Envoy-External-Address delete
+		}
 	}
 }
 

--- a/docker/otel-collector/builder-config.yaml
+++ b/docker/otel-collector/builder-config.yaml
@@ -26,6 +26,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.157.0
   # Upserts Middleware's routing attribute (mw.account_key).
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.157.0
+  # Drops the visitor-IP span attribute (client.address) before export.
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.157.0
 
 exporters:
   # Ships everything to Middleware over OTLP/gRPC.

--- a/docker/otel-collector/config.yaml
+++ b/docker/otel-collector/config.yaml
@@ -43,19 +43,12 @@ receivers:
           parse_from: attributes.traceID
         span_id:
           parse_from: attributes.spanID
-      # Strip visitor-IP-bearing request headers before export. With no
-      # trusted_proxies in Caddy, remote_ip/client_ip are the Scaleway edge (not a
-      # visitor, so retained); the real visitor IP only rides in X-Forwarded-For /
-      # X-Real-Ip. Removing them here keeps the visitor IP out of Middleware — it
-      # still lands transiently in the on-disk access.log, which never leaves the
-      # container. The guards skip runtime.log lines (no request object), which
-      # would otherwise trip the remove operator's missing-field error.
-      - type: remove
-        if: 'attributes.request != nil and attributes.request.headers != nil and attributes.request.headers["X-Forwarded-For"] != nil'
-        field: attributes.request.headers["X-Forwarded-For"]
-      - type: remove
-        if: 'attributes.request != nil and attributes.request.headers != nil and attributes.request.headers["X-Real-Ip"] != nil'
-        field: attributes.request.headers["X-Real-Ip"]
+      # The visitor-IP-bearing request headers (X-Forwarded-For, X-Real-Ip,
+      # Forwarded, X-Envoy-External-Address) are deleted at the Caddy source (the
+      # (otel) log filter in the Caddyfile), so they are absent from both the
+      # parsed attributes and the raw line body by the time the collector reads
+      # them — nothing to strip here. remote_ip/client_ip are the loopback
+      # Scaleway edge, not a visitor.
 
 processors:
   # Refuse data instead of OOM-killing the container when memory is tight.
@@ -88,6 +81,17 @@ processors:
         value: ${env:MIDDLEWARE_API_KEY}
         action: upsert
 
+  # Drop the visitor IP from spans. Caddy's tracing sets client.address from the
+  # X-Forwarded-For header (the real visitor IP) and exposes no way to suppress
+  # it, so delete it here — centrally, before export — on every span (web-proxy
+  # today; also covers quote-api should it ever see a real IP).
+  transform/scrub_client_ip:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - delete_key(attributes, "client.address")
+
   batch:
     send_batch_size: 512
     timeout: 5s
@@ -107,7 +111,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, resource_detection, resource/middleware, batch]
+      processors: [memory_limiter, transform/scrub_client_ip, resource_detection, resource/middleware, batch]
       exporters: [otlp_grpc/middleware]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
_No linked issue._

## 📑 Description

Stops the site from leaking **visitor IP addresses** to Middleware (our third-party observability processor), closing the gap between actual behaviour and what [`privacy.md`](swa/src/pages/privacy.md) promises: *"Visitor IP addresses are removed before telemetry is sent."* That statement was **not** true — the real client IP was reaching Middleware through two independent paths. Both are now closed at the source of each.

### What was leaking, and where it's fixed

| Leak | Root cause | Fixed at |
| --- | --- | --- |
| `web-proxy` **trace** attribute `client.address` (real visitor IP, e.g. `35.85.57.67`) | Caddy's `tracing` uses otelhttp, which derives `client.address` from `X-Forwarded-For`; Caddy exposes no knob to suppress it | **Collector** |
| Caddy **`access.log`** request headers `Forwarded`, `X-Forwarded-For`, `X-Real-Ip`, `X-Envoy-External-Address` | The `(otel)` snippet logged with the plain `json` encoder, which writes the full header map | **Caddy source** |

### Architectural decision — fix each leak at the layer that can actually remove it

The instinct is to scrub everything centrally in the collector, but that only works for the trace:

- **Trace `client.address` → collector.** Caddy can't drop the span attribute, so a collector `transform` processor deletes it from every span before export. This is the correct central choke point, and running on all spans also covers `quote-api` if it ever sees a real IP.
- **Log headers → Caddy source.** The collector *cannot* fully sanitise these: the `filelog` receiver retains the raw log line as the record `body` (shipped to Middleware as `body`/`body512`), and a `remove` operator only edits the *parsed* attributes — not the raw body. That's exactly why `X-Forwarded-For` still showed up in `body` even though a prior `remove` operator existed. Deleting the headers with Caddy's `filter` log encoder removes them from the parsed fields, the raw body, **and** the on-disk file in one move.

Anonymisation method: the IP is **dropped entirely** (not masked to a /24), which keeps the privacy-policy wording literally true.

### Changes per file

- **[docker/caddy/Caddyfile](docker/caddy/Caddyfile)** — the `(otel)` access-log block switches from `format json` to `format filter { … delete }` for the four visitor-IP headers. (`remote_ip`/`client_ip` are the loopback Scaleway edge, so they need no masking.)
- **[docker/otel-collector/builder-config.yaml](docker/otel-collector/builder-config.yaml)** — adds the `transformprocessor` module to the minimal OCB build (it wasn't compiled in before).
- **[docker/otel-collector/config.yaml](docker/otel-collector/config.yaml)** — adds a `transform/scrub_client_ip` processor (`delete_key(attributes, "client.address")`) and wires it into the **traces** pipeline; removes the two now-redundant `filelog` `remove` operators (superseded by the Caddy-source deletion) and updates the comments.

### Not changed (audited, already clean)

- [x] **Scaleway / container stdout** — Caddy routes its logs to files; `api` and `otel-collector` sit behind s6-log pipelines. No client IPs reach container stdout.
- [x] **`quote-api` OTLP logs** — `client_ip` resolves to `127.0.0.1` (Caddy doesn't trust the inbound XFF).
- [x] **Metrics** — aggregate, no per-client labels.

## ✅ Checks

- [x] My pull request matches to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

- **Validation (no automated test covers these configs, so both were validated manually):**
  - `caddy validate` in `caddy:2.11.4-alpine` → *"Valid configuration"*.
  - `otelcol validate` in `otel/opentelemetry-collector-contrib:0.157.0` → exit `0` (accepts the `transform` OTTL processor and its traces-pipeline wiring). The one-line `transformprocessor` gomod addition is compiled by the OCB stage during `docker-build`/CI.
- **Documentation:** no change required — `privacy.md`'s existing claim becomes accurate once this ships; nothing to reword.
- **No dependencies added at runtime**; the collector build gains one contrib processor module (`transformprocessor`), consistent with the existing minimal-OCB approach.
- **Suggested end-to-end check before merge:** `task docker-build`, run locally, then
  `curl -s -o /dev/null -H "X-Forwarded-For: 203.0.113.45" -H "Forwarded: for=203.0.113.45" -H "X-Envoy-External-Address: 203.0.113.45" http://localhost:8080/` — confirm the `web-proxy` span has no `client.address` and the new `access.log` line (and its `body`) carries none of the four headers.
